### PR TITLE
Add addMetadata(...) function for crash reporting

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,7 +145,6 @@ The following authentication methods are available:
 1. AuthenticationType.Anonymous - Anonymous Authentication
 1. AuthenticationType.EmailSecret - HockeyApp email & App Secret
 1. AuthenticationType.EmailPassword - HockeyApp email & password
-1. AuthenticationType.DeviceUUID - HockeyApp registered devie UUID
 1. AuthenticationType.DeviceUUID - HockeyApp registered device UUID
 1. AuthenticationType.Web - HockeyApp Web Auth (iOS only)
 

--- a/README.md
+++ b/README.md
@@ -133,10 +133,11 @@ componentDidMount() {
 
 You have available these methods:
 ```js
-HockeyApp.configure(HockeyAppId:string, autoSendCrashReports:boolean = true, authenticationType:AuthenticationType = AuthenticationType.Anonymous, appSecret: string = ''); // Configure the settings
+HockeyApp.configure(HockeyAppId: string, autoSendCrashReports: boolean = true, authenticationType: AuthenticationType = AuthenticationType.Anonymous, appSecret: string = '', ignoreDefaultHandler: string = false); // Configure the settings
 HockeyApp.start(); // Start the HockeyApp integration
 HockeyApp.checkForUpdate(); // Check if there's new version and if so trigger update
 HockeyApp.feedback(); // Ask user for feedback.
+HockeyApp.addMetadata(metadata: object); // Add metadata to crash report.  The argument must be an object with key-value pairs.
 HockeyApp.generateTestCrash(); // Generate test crash. Only works in no-debug mode.
 ```
 The following authentication methods are available:
@@ -145,7 +146,8 @@ The following authentication methods are available:
 1. AuthenticationType.EmailSecret - HockeyApp email & App Secret
 1. AuthenticationType.EmailPassword - HockeyApp email & password
 1. AuthenticationType.DeviceUUID - HockeyApp registered devie UUID
+1. AuthenticationType.DeviceUUID - HockeyApp registered device UUID
 1. AuthenticationType.Web - HockeyApp Web Auth (iOS only)
 
 # Contributions
-@martincik, @berickson1, @rspeyer 
+@martincik, @berickson1, @rspeyer, @dtivel

--- a/RNHockeyApp/RNHockeyApp.m
+++ b/RNHockeyApp/RNHockeyApp.m
@@ -7,11 +7,14 @@ static AuthType authType = 0;
 static NSString *token = nil;
 static NSString *appSecret = nil;
 
+@interface RNHockeyApp() <BITHockeyManagerDelegate, BITCrashManagerDelegate>
+@end
+
 @implementation RNHockeyApp
 
 RCT_EXPORT_MODULE();
 
-RCT_EXPORT_METHOD(configure:(NSString *) apiToken autoSend:(BOOL) autoSendCrashes authType:(NSInteger) apiAuthType appSecret:(NSString*) apiAppSecret)
+RCT_EXPORT_METHOD(configure:(NSString *) apiToken autoSend:(BOOL) autoSendCrashes authType:(NSInteger) apiAuthType appSecret:(NSString*) apiAppSecret ignoreDefaultHandler:(BOOL) ignoreDefaultCrashHandler)
 {
     if (initialized == NO) {
         autoSend = autoSendCrashes;
@@ -27,7 +30,8 @@ RCT_EXPORT_METHOD(configure:(NSString *) apiToken autoSend:(BOOL) autoSendCrashe
 RCT_EXPORT_METHOD(start) {
     if (initialized == YES) {
         dispatch_async(dispatch_get_main_queue(), ^{
-            [[BITHockeyManager sharedHockeyManager] configureWithIdentifier:token];
+            [[BITHockeyManager sharedHockeyManager] configureWithIdentifier:token
+                                                                   delegate:self];
             if (autoSend == YES) {
                 [[BITHockeyManager sharedHockeyManager].crashManager setCrashManagerStatus:BITCrashManagerStatusAutoSend];
             }
@@ -57,10 +61,34 @@ RCT_EXPORT_METHOD(start) {
             }
             [[BITHockeyManager sharedHockeyManager] startManager];
             [[BITHockeyManager sharedHockeyManager].authenticator authenticateInstallation];
+
+            [RNHockeyApp deleteMetadataFileIfExists];
         });
     }
 }
 
+RCT_EXPORT_METHOD(addMetadata:(NSData*) metadata)
+{
+    if (initialized == YES) {
+        NSDictionary *newMetadata = [NSJSONSerialization JSONObjectWithData:metadata options:0 error:nil];
+
+        if (!newMetadata) {
+           NSLog(@"react-native-hockeyapp: the metadata is not valid JSON.");
+           return;
+        }
+
+        NSMutableDictionary *allMetadata = [RNHockeyApp getExistingMetadata];
+        [allMetadata addEntriesFromDictionary:newMetadata];
+        NSData *json = [NSJSONSerialization dataWithJSONObject:allMetadata options:0 error:nil];
+
+        if (json) {
+            NSString *filePath = [RNHockeyApp getMetadataFilePath];
+            [json writeToFile:filePath atomically:YES];
+        }
+    } else {
+        NSLog(@"Not initialized! \n");
+    }
+}
 
 RCT_EXPORT_METHOD(feedback)
 {
@@ -85,6 +113,45 @@ RCT_EXPORT_METHOD(generateTestCrash)
     if (initialized == YES) {
         [[BITHockeyManager sharedHockeyManager].crashManager generateTestCrash];
     }
+}
+
++ (void)deleteMetadataFileIfExists
+{
+    NSString *filePath = [RNHockeyApp getMetadataFilePath];
+
+    [[NSFileManager defaultManager] removeItemAtPath:filePath error:nil];
+}
+
++ (NSMutableDictionary *)getExistingMetadata
+{
+    NSString *filePath = [RNHockeyApp getMetadataFilePath];
+    NSData *data = [NSData dataWithContentsOfFile:filePath];
+    NSMutableDictionary *dictionary = nil;
+
+    if (data) {
+        dictionary = [[NSJSONSerialization JSONObjectWithData:data options:0 error:nil] mutableCopy];
+    }
+
+    if (!dictionary) {
+        dictionary = [NSMutableDictionary new];
+    }
+
+    return dictionary;
+}
+
++ (NSString *)getMetadataFilePath
+{
+    BOOL expandTilde = YES;
+    NSString *directoryPath = [NSSearchPathForDirectoriesInDomains (NSLibraryDirectory, NSUserDomainMask, expandTilde) objectAtIndex:0];
+
+    return [directoryPath stringByAppendingPathComponent:@"HockeyAppCrashMetadata.json"];
+}
+
+- (NSString *)applicationLogForCrashManager:(BITCrashManager *)crashManager
+{
+    NSString *filePath = [RNHockeyApp getMetadataFilePath];
+
+    return [NSString stringWithContentsOfFile:filePath encoding:NSUTF8StringEncoding error:nil];
 }
 
 @end

--- a/android/src/main/java/com/slowpath/hockeyapp/RNHockeyAppModule.java
+++ b/android/src/main/java/com/slowpath/hockeyapp/RNHockeyAppModule.java
@@ -7,11 +7,11 @@ import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReactContextBaseJavaModule;
 import com.facebook.react.bridge.ReactMethod;
 
+import net.hockeyapp.android.CrashManager;
+import net.hockeyapp.android.CrashManagerListener;
 import net.hockeyapp.android.FeedbackManager;
 import net.hockeyapp.android.LoginManager;
 import net.hockeyapp.android.UpdateManager;
-import net.hockeyapp.android.CrashManager;
-import net.hockeyapp.android.CrashManagerListener;
 
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -19,11 +19,11 @@ import org.json.JSONObject;
 import java.io.BufferedInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.lang.Runnable;
+import java.lang.RuntimeException;
+import java.lang.Thread;
 import java.text.SimpleDateFormat;
 import java.util.Calendar;
-import java.lang.RuntimeException;
-import java.lang.Runnable;
-import java.lang.Thread;
 import java.util.Iterator;
 
 public class RNHockeyAppModule extends ReactContextBaseJavaModule {

--- a/index.js
+++ b/index.js
@@ -17,9 +17,9 @@ module.exports = {
         DeviceUUID: 3,
         Web: 4
     },
-    configure(apiToken, autoSendCrashes, authenticationType, apiSecret) {
+    configure(apiToken, autoSendCrashes, authenticationType, apiSecret, ignoreDefaultHandler) {
         checkInstalled();
-        RNHockeyApp.configure(apiToken, autoSendCrashes || true, authenticationType || 0, apiSecret || '');
+        RNHockeyApp.configure(apiToken, autoSendCrashes || true, authenticationType || 0, apiSecret || '', ignoreDefaultHandler || false);
     },
     start(){
         checkInstalled();
@@ -32,6 +32,11 @@ module.exports = {
     feedback(){
         checkInstalled();
         RNHockeyApp.feedback();
+    },
+    addMetadata(metadata){
+        checkInstalled();
+        var json = JSON.stringify(metadata);
+        RNHockeyApp.addMetadata(json);
     },
     generateTestCrash(){
         checkInstalled();


### PR DESCRIPTION
Enable adding custom metadata to crash reports and customizing default
crash handler.

Note:  the HockeyApp SDK does not offer an iOS counterpart to Android’s
CrashManagerListener.ignoreDefaultHandler(), so the option is ignored
on iOS.
