### PR TITLE
fix of NullPointerException because of hockey app API abuse

### DIFF
--- a/android/src/main/java/com/slowpath/hockeyapp/RNHockeyAppModule.java
+++ b/android/src/main/java/com/slowpath/hockeyapp/RNHockeyAppModule.java
@@ -101,7 +101,7 @@ public class RNHockeyAppModule extends ReactContextBaseJavaModule {
         }
       }
 
-      LoginManager.register(_context, _token, _appSecret, authenticationMode, (Class<?>) null);
+      LoginManager.register(_context, _token, _appSecret, authenticationMode, _activity.getClass());
       LoginManager.verifyLogin(_activity, _activity.getIntent());
 
       _crashManagerListener.deleteMetadataFileIfExists();


### PR DESCRIPTION
We have a crash with following stacktrace, because of abuse register method usage
java.lang.NullPointerException: Attempt to invoke virtual method 'java.lang.String java.lang.Class.getName()' on a null object reference
    at android.content.ComponentName.<init>(ComponentName.java:129)
    at android.content.Intent.<init>(Intent.java:5295)
    at net.hockeyapp.android.LoginActivity.onKeyDown(LoginActivity.java:150)
    at android.view.KeyEvent.dispatch(KeyEvent.java:3256)
    at android.app.Activity.dispatchKeyEvent(Activity.java:2982)
    at com.android.internal.policy.PhoneWindow$DecorView.dispatchKeyEvent(PhoneWindow.java:2697)
    at android.view.ViewRootImpl$ViewPostImeInputStage.processKeyEvent(ViewRootImpl.java:5226)
    at android.view.ViewRootImpl$ViewPostImeInputStage.onProcess(ViewRootImpl.java:5179)
    at android.view.ViewRootImpl$InputStage.deliver(ViewRootImpl.java:4626)
    at android.view.ViewRootImpl$InputStage.onDeliverToNext(ViewRootImpl.java:4679)
    at android.view.ViewRootImpl$InputStage.forward(ViewRootImpl.java:4645)
    at android.view.ViewRootImpl$AsyncInputStage.forward(ViewRootImpl.java:4787)
    at android.view.ViewRootImpl$InputStage.apply(ViewRootImpl.java:4653)
    at android.view.ViewRootImpl$AsyncInputStage.apply(ViewRootImpl.java:4844)
    at android.view.ViewRootImpl$InputStage.deliver(ViewRootImpl.java:4626)
    at android.view.ViewRootImpl$InputStage.onDeliverToNext(ViewRootImpl.java:4679)
    at android.view.ViewRootImpl$InputStage.forward(ViewRootImpl.java:4645)
    at android.view.ViewRootImpl$InputStage.apply(ViewRootImpl.java:4653)
    at android.view.ViewRootImpl$InputStage.deliver(ViewRootImpl.java:4626)
    at android.view.ViewRootImpl$InputStage.onDeliverToNext(ViewRootImpl.java:4679)
    at android.view.ViewRootImpl$InputStage.forward(ViewRootImpl.java:4645)
    at android.view.ViewRootImpl$AsyncInputStage.forward(ViewRootImpl.java:4820)
    at android.view.ViewRootImpl$ImeInputStage.onFinishedInputEvent(ViewRootImpl.java:5063)
    at android.view.inputmethod.InputMethodManager$PendingEvent.run(InputMethodManager.java:2877)
    at android.view.inputmethod.InputMethodManager.invokeFinishedInputEventCallback(InputMethodManager.java:2449)
    at android.view.inputmethod.InputMethodManager.finishedInputEvent(InputMethodManager.java:2440)
    at android.view.inputmethod.InputMethodManager$ImeInputEventSender.onInputEventFinished(InputMethodManager.java:2854)
    at android.view.InputEventSender.dispatchInputEventFinished(InputEventSender.java:141)
    at android.os.MessageQueue.nativePollOnce(Native Method)
    at android.os.MessageQueue.next(MessageQueue.java:323)
    at android.os.Looper.loop(Looper.java:143)
    at android.app.ActivityThread.main(ActivityThread.java:7229)
    at java.lang.reflect.Method.invoke(Native Method)
    at com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run(ZygoteInit.java:1230)
    at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:1120)
