### PR TITLE
Adapt to support Android in React Native 0.29

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 - iOS 7+
 - Android
-- React Native >0.14
+- React Native >0.17
 - CocoaPods
 
 ## Installation
@@ -51,7 +51,7 @@ If you wish to use Device UUID authentication or Web authentication, the followi
 }
 ```
 
-## Android
+## Android (React Native >= 0.29)
 
 ### Google project configuration
 
@@ -85,7 +85,75 @@ apply plugin: "com.android.application"
 dependencies {
     compile fileTree(dir: "libs", include: ["*.jar"])
     compile "com.android.support:appcompat-v7:23.0.1"
-    compile "com.facebook.react:react-native:0.19.+"
+    compile "com.facebook.react:react-native:0.29.+"
+    compile project(":react-native-hockeyapp") // <--- add this
+}
+```
+
+* Manifest file
+```xml
+<application ..>
+    <activity android:name="net.hockeyapp.android.UpdateActivity" />
+    <activity android:name="net.hockeyapp.android.FeedbackActivity" />
+</application>
+```
+
+* Register Module (in MainApplication.java)
+
+```java
+import com.slowpath.hockeyapp.RNHockeyAppModule; // <--- import
+import com.slowpath.hockeyapp.RNHockeyAppPackage;  // <--- import
+
+public class MainApplication extends Application implements ReactApplication {
+  ......
+
+  @Override
+  protected List<ReactPackage> getPackages() {
+    return Arrays.<ReactPackage>asList(
+      new RNHockeyAppPackage(MainApplication.this), // <------ add this line to yout MainApplication class
+      new MainReactPackage());
+  }
+
+  ......
+
+}
+```
+
+## Android (React Native 0.17 - 0.28)
+
+### Google project configuration
+
+* In `android/setting.gradle`
+
+```gradle
+...
+include ':react-native-hockeyapp', ':app'
+project(':react-native-hockeyapp').projectDir = new File(rootProject.projectDir, '../node_modules/react-native-hockeyapp/android')
+```
+
+* In `android/build.gradle`
+
+```gradle
+...
+repositories {
+    jcenter()
+    mavenCentral()
+}
+dependencies {
+    classpath 'com.android.tools.build:gradle:1.3.1'
+    classpath 'net.hockeyapp.android:HockeySDK:3.7.0' // <--- add this
+}
+```
+
+* In `android/app/build.gradle`
+
+```gradle
+apply plugin: "com.android.application"
+...
+dependencies {
+    compile fileTree(dir: "libs", include: ["*.jar"])
+    compile "com.android.support:appcompat-v7:23.0.1"
+    compile "com.facebook.react:react-native:0.17.+"
     compile project(":react-native-hockeyapp") // <--- add this
 }
 ```

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -18,6 +18,6 @@ android {
 dependencies {
     compile fileTree(include: ['*.jar'], dir: 'libs')
     compile "com.android.support:appcompat-v7:23.0.1"
-    compile 'com.facebook.react:react-native:0.14.+'
+    compile 'com.facebook.react:react-native:0.17.+'
     compile 'net.hockeyapp.android:HockeySDK:4.0.1'
 }

--- a/android/src/main/java/com/slowpath/hockeyapp/RNHockeyAppModule.java
+++ b/android/src/main/java/com/slowpath/hockeyapp/RNHockeyAppModule.java
@@ -36,7 +36,6 @@ public class RNHockeyAppModule extends ReactContextBaseJavaModule {
   public static final int AUTHENTICATION_TYPE_DEVICE_UUID = 3;
   public static final int AUTHENTICATION_TYPE_WEB = 4; // Included for consistency, but not supported on Android currently
 
-  private Activity _activity;
   private static ReactApplicationContext _context;
   public static boolean _initialized = false;
   public static String _token = null;
@@ -46,10 +45,9 @@ public class RNHockeyAppModule extends ReactContextBaseJavaModule {
   public static String _appSecret = null;
   public static RNHockeyCrashManagerListener _crashManagerListener = null;
 
-  public RNHockeyAppModule(ReactApplicationContext _reactContext, Activity activity) {
+  public RNHockeyAppModule(ReactApplicationContext _reactContext) {
     super(_reactContext);
     _context = _reactContext;
-    _activity = activity;
   }
 
   @Override
@@ -72,10 +70,13 @@ public class RNHockeyAppModule extends ReactContextBaseJavaModule {
 
   @ReactMethod
   public void start() {
-    if (_initialized) {
-      FeedbackManager.register(_activity, _token, null);
 
-      CrashManager.register(_activity, _token, _crashManagerListener);
+    Activity currentActivity = getCurrentActivity();
+
+    if (_initialized) {
+      FeedbackManager.register(currentActivity, _token, null);
+
+      CrashManager.register(currentActivity, _token, _crashManagerListener);
 
       int authenticationMode;
       switch (_authType) {
@@ -101,8 +102,8 @@ public class RNHockeyAppModule extends ReactContextBaseJavaModule {
         }
       }
 
-      LoginManager.register(_context, _token, _appSecret, authenticationMode, _activity.getClass());
-      LoginManager.verifyLogin(_activity, _activity.getIntent());
+      LoginManager.register(_context, _token, _appSecret, authenticationMode, currentActivity.getClass());
+      LoginManager.verifyLogin(currentActivity, currentActivity.getIntent());
 
       _crashManagerListener.deleteMetadataFileIfExists();
     }
@@ -110,27 +111,29 @@ public class RNHockeyAppModule extends ReactContextBaseJavaModule {
 
   @ReactMethod
   public void checkForUpdate() {
+    Activity currentActivity = getCurrentActivity();
     if (_initialized) {
-      UpdateManager.register(_activity, _token);
+      UpdateManager.register(currentActivity, _token);
     }
   }
 
   @ReactMethod
   public void feedback() {
+    Activity currentActivity = getCurrentActivity();
     if (_initialized) {
-      _activity.runOnUiThread(new Runnable() {
-        private Activity _activity;
+      currentActivity.runOnUiThread(new Runnable() {
+        private Activity currentActivity;
 
         public Runnable init(Activity activity) {
-          _activity = activity;
+          currentActivity = activity;
           return (this);
         }
 
         @Override
         public void run() {
-          FeedbackManager.showFeedbackActivity(_activity);
+          FeedbackManager.showFeedbackActivity(currentActivity);
         }
-      }.init(_activity));
+      }.init(currentActivity));
     }
   }
 

--- a/android/src/main/java/com/slowpath/hockeyapp/RNHockeyAppPackage.java
+++ b/android/src/main/java/com/slowpath/hockeyapp/RNHockeyAppPackage.java
@@ -1,5 +1,6 @@
 package com.slowpath.hockeyapp;
 
+import android.app.Application;
 import android.app.Activity;
 
 import com.facebook.react.bridge.JavaScriptModule;
@@ -15,18 +16,17 @@ import java.util.List;
 public class RNHockeyAppPackage implements ReactPackage {
   private Activity _activity;
 
-  public RNHockeyAppPackage(Activity activity) {
+  public RNHockeyAppPackage(Application application) {
     super();
-    _activity = activity;
-
-    RNHockeyAppUsageTracker.initialize(activity.getApplication());
+    
+    RNHockeyAppUsageTracker.initialize(application);
   }
 
   @Override
   public List<NativeModule> createNativeModules(ReactApplicationContext reactContext) {
     List<NativeModule> modules = new ArrayList<>();
 
-    modules.add(new RNHockeyAppModule(reactContext, _activity));
+    modules.add(new RNHockeyAppModule(reactContext));
 
     return modules;
   }


### PR DESCRIPTION
A fix for https://github.com/slowpath/react-native-hockeyapp/issues/28

I haven't tested this with React Native < 0.29 but in theory it should work with version 17.0 and up, which was when `getCurrentActivity` was added.

Disclaimer: I'm not a Java developer
