### PR TITLE
Add trackEventWithOptionsAndMeasurements method

### DIFF
--- a/RNHockeyApp/RNHockeyApp.m
+++ b/RNHockeyApp/RNHockeyApp.m
@@ -131,6 +131,18 @@ RCT_EXPORT_METHOD(trackEvent:(NSString *)eventName)
     }
 }
 
+RCT_EXPORT_METHOD(trackEventWithOptionsAndMeasurements:(NSString *)eventName Options:(NSDictionary *)options Measurements:(NSDictionary *)measurements)
+{
+  if (initialized == YES) {
+    if ([eventName length] > 0) {
+      BITMetricsManager *metricsManager = [[BITHockeyManager sharedHockeyManager] metricsManager];
+      [metricsManager trackEventWithName:eventName properties:options measurements:measurements];
+    } else {
+      NSLog(@"react-native-hockeyapp: An event name must be provided.");
+    }
+  }
+}
+
 + (void)deleteMetadataFileIfExists
 {
     NSString *filePath = [RNHockeyApp getMetadataFilePath];

--- a/android/src/main/java/com/slowpath/hockeyapp/RNHockeyAppModule.java
+++ b/android/src/main/java/com/slowpath/hockeyapp/RNHockeyAppModule.java
@@ -29,6 +29,7 @@ import java.lang.Thread;
 import java.text.SimpleDateFormat;
 import java.util.Calendar;
 import java.util.Iterator;
+import java.util.Map;
 
 public class RNHockeyAppModule extends ReactContextBaseJavaModule {
   public static final int RC_HOCKEYAPP_IN = 9200;
@@ -183,6 +184,15 @@ public class RNHockeyAppModule extends ReactContextBaseJavaModule {
     {
       log(eventName);
        MetricsManager.trackEvent(eventName);
+    }
+  }
+
+   @ReactMethod
+  public void trackEventWithOptionsAndMeasurements(String eventName, Map<String,String> properties, Map<String,Double> measurements) {
+    if(_initialized)
+    {
+      log(eventName);
+       MetricsManager.trackEvent(eventName, properties, measurements));
     }
   }
 

--- a/index.js
+++ b/index.js
@@ -45,6 +45,10 @@ module.exports = {
     trackEvent(eventName) {
         checkInstalled();
         RNHockeyApp.trackEvent(eventName);
+    },
+    trackEventWithOptionsAndMeasurements(eventName, options, measurements) {
+        checkInstalled();
+        RNHockeyApp.trackEventWithOptionsAndMeasurements(eventName, options || {}, measurements || {});
     }
 }
 


### PR DESCRIPTION
Tracking events with name doesn't really allow us to provide information around these events. I have added a new method called trackEventWithOptionsAndMeasurements which plugs into the hockey app method for providing options and measurements with each event.