### PR TITLE
Changed react native dependency to `+`

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -18,6 +18,6 @@ android {
 dependencies {
     compile fileTree(include: ['*.jar'], dir: 'libs')
     compile "com.android.support:appcompat-v7:23.0.1"
-    compile 'com.facebook.react:react-native:0.17.+'
+    compile 'com.facebook.react:react-native:+'
     compile 'net.hockeyapp.android:HockeySDK:4.1.2'
 }


### PR DESCRIPTION
Found an issue where Gradle was only looking for react-native within version 0.17 (rather than higher than). There is [syntax for doing "more than"](http://central.sonatype.org/articles/2014/Oct/28/enforcing-valid-dependency-versions/) but I couldn't get it to work; possible due to Gradle version