### PR TITLE
Fix build of RN projects that use default HockeyApp SDK without Feedback on iOS

### DIFF
--- a/RNHockeyApp/RNHockeyApp.m
+++ b/RNHockeyApp/RNHockeyApp.m
@@ -94,6 +94,7 @@ RCT_EXPORT_METHOD(addMetadata:(NSData*) metadata)
     }
 }
 
+#if HOCKEYSDK_FEATURE_FEEDBACK
 RCT_EXPORT_METHOD(feedback)
 {
     if (initialized == YES) {
@@ -102,6 +103,12 @@ RCT_EXPORT_METHOD(feedback)
         NSLog(@"Not initialized! \n");
     }
 }
+#else
+RCT_EXPORT_METHOD(feedback)
+{
+    NSLog(@"Feedback not included in HockeyApp SDK installation! \n");
+}
+#endif
 
 RCT_EXPORT_METHOD(checkForUpdate)
 {


### PR DESCRIPTION
First, thanks for your work on this module, it's been a huge help for me and I really appreciate it!

This pull request removes the reference to the HockeyApp SDK Feedback feature on iOS when it's not present in the local build of the SDK.

Per the HockeyApp documentation, link below, "As of HockeySDK 4.1.1, Feedback is no longer part of the default SDK".

https://support.hockeyapp.net/kb/client-integration-ios-mac-os-x-tvos/hockeyapp-for-ios#feedback

Print a warning message when missing if called at runtime.

I can confirm that this builds fine when using the default HockeyApp SDK on iOS without Feedback.