### PR TITLE
Update build.gradle to use implementation

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -16,8 +16,8 @@ android {
 }
 
 dependencies {
-    compile fileTree(include: ['*.jar'], dir: 'libs')
-    compile "com.android.support:appcompat-v7:23.0.1"
-    compile 'com.facebook.react:react-native:0.17.+'
-    compile 'net.hockeyapp.android:HockeySDK:4.1.2'
+    implementation fileTree(include: ['*.jar'], dir: 'libs')
+    implementation "com.android.support:appcompat-v7:23.0.1"
+    implementation 'com.facebook.react:react-native:0.17.+'
+    implementation 'net.hockeyapp.android:HockeySDK:4.1.2'
 }


### PR DESCRIPTION
The use of 'compile' in build.gradle is deprecated in favor or 'implementation' and/or 'api'